### PR TITLE
Add support for null values in compared objects

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -130,7 +130,7 @@
             return [{op: 'replace', path: buildPath(path), value: val2}];
         }
 
-        if (typeof val1 !== 'object' || typeof val2 !== 'object') {
+        if (typeof val1 !== 'object' || typeof val2 !== 'object' || val1 === null || val2 === null) {
             if (val1 === val2) {
                 return [];
             }

--- a/test/diff.js
+++ b/test/diff.js
@@ -116,6 +116,18 @@ describe('#diff()', function() {
             obj2 = {nested: {inner: {something: 8}}};
         expect(diff(obj1, obj2)).to.contain({ op: 'replace', path: '/nested/inner/something', value: 8 });
     });
+    
+    it('should support nested replaces of null', function(){
+        var obj1 = {nested: {inner: null}},
+            obj2 = {nested: {inner: {something: 8}}};
+        expect(diff(obj1, obj2)).to.contain({ op: 'replace', path: '/nested/inner', value: {something: 8} });
+    });
+    
+    it('should support nested replaces by null', function(){
+        var obj1 = {nested: {inner: {something: 5}}},
+            obj2 = {nested: {inner: null}};
+        expect(diff(obj1, obj2)).to.contain({ op: 'replace', path: '/nested/inner', value: null });
+    });
 
     it('should support a single top-level remove in an array leaving it empty', function(){
         var obj1 = ['foo'],


### PR DESCRIPTION
Following comparisons throws exceptions:
`diff({nested: {inner: null}}, {nested: {inner: {something: 8}}})`
`diff({nested: {inner: {something: 5}}}, {nested: {inner: null}})`

This is caused by a comparison not taking null values into account. Because `typeof null` surprisingly equals to `'object'` (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#null)